### PR TITLE
Fix a bug that caused fromDate to be null

### DIFF
--- a/client/pages/NewEvent.js
+++ b/client/pages/NewEvent.js
@@ -160,6 +160,8 @@ class NewEvent extends React.Component {
         sentData = JSON.stringify({ uid, name, weekDays });
       } else {
         const dates = ranges.map(({ from, to }) => {
+          if (!to) to = from;
+
           if (from > to) {
             [from, to] = [to, from];
           }


### PR DESCRIPTION
When a single date is selected, the `to` field in the range object is
null which causes the fromDate property of the dates object to be null,
crapping out the availability grid.
